### PR TITLE
feat: let micro handle the response encoding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,57 @@
 import { ServerResponse, IncomingMessage } from "http";
 import { RequestHandler } from "micro";
 
+type MicroRequestHandlerResponse = ReturnType<RequestHandler>;
+
 export type ResponseChainHandler = (
   req: IncomingMessage,
   res: ServerResponse,
   next: Function
-) => any;
+) => undefined;
+
+type ResponseHandlerParameter = ResponseChainHandler | RequestHandler;
+type ResponseParameter = MicroRequestHandlerResponse | ResponseHandlerParameter;
 
 type Parameters = {
   errorCode?: number;
-  response?: string | object | ResponseChainHandler;
+  response?: ResponseParameter;
   contentType?: string;
 };
 
 const ALLOWED_HTTP_METHOD = "POST";
+
+const isValidHandler = (
+  response: ResponseParameter
+): response is ResponseHandlerParameter => {
+  if (typeof response === "function") {
+    return true;
+  }
+
+  return false;
+};
+
+const isResponseChainHandler = (
+  response: ResponseParameter
+): response is ResponseChainHandler => {
+  if (isValidHandler(response)) {
+    // is ResponseChainHandler, this one must have three (3) arguments
+    if (response.length === 3) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const isRequestHandler = (
+  response: ResponseParameter
+): response is RequestHandler => {
+  if (isValidHandler(response) && !isResponseChainHandler(response)) {
+    return true;
+  }
+
+  return false;
+};
 
 function post(fn: RequestHandler): RequestHandler;
 function post(params: Parameters, fn: RequestHandler): RequestHandler;
@@ -40,33 +78,28 @@ function post(
   const { errorCode = 405 } = params;
 
   // Get custom response of default
-  let { response = "Method Not Allowed", contentType = "text/plain" } = params;
-
-  if (typeof response === "object") {
-    response = JSON.stringify(response);
-    contentType = "application/json";
-  }
-
-  const contentLength = Buffer.byteLength(response.toString());
+  let { response = "Method Not Allowed" } = params;
 
   return (req, res) => {
     res.setHeader("Access-Control-Request-Method", ALLOWED_HTTP_METHOD);
     const { method } = req;
     if (method != ALLOWED_HTTP_METHOD) {
       res.statusCode = errorCode;
-      if (typeof response === "function") {
+      if (isResponseChainHandler(response)) {
         // Execute custom response of function type
-        return (<ResponseChainHandler>response)(req, res, () => {
+        return response(req, res, () => {
           res.end();
         });
+      } else if (isRequestHandler(response)) {
+        return response(req, res);
       }
 
-      res.setHeader("Content-Type", contentType);
-      res.setHeader("Content-Length", contentLength);
-      res.write(response);
+      // stay backwards compatible
+      if (params.contentType || typeof response === "string") {
+        res.setHeader("Content-Type", params.contentType || "text/plain");
+      }
 
-      res.end();
-      return;
+      return response;
     }
 
     return handler(req, res);
@@ -74,7 +107,7 @@ function post(
 }
 
 // typescript/es6 compatible default export
-export default post
+export default post;
 
 // backward compatible (nodejs require) exports
-module.exports = exports = post
+module.exports = exports = post;


### PR DESCRIPTION
micro is able to encode various data formats like: text, json, buffer and streams

Delegating the encoding of the response to micro opens up the use-cases where micro-post is applicable and also reduced redundancy of encoding implementations.
This branch includes an extension with which it is possible to pass a default micro RequestHandler as response handler function, profiting too of micros encoding capabilities.
Using the test suite I confirmed these changes are backwards compatible.